### PR TITLE
C++: Use variableAccessedAsValue in LargeParameter

### DIFF
--- a/cpp/ql/src/Critical/LargeParameter.ql
+++ b/cpp/ql/src/Critical/LargeParameter.ql
@@ -22,12 +22,12 @@ where f.getAParameter() = p
   and not f instanceof CopyAssignmentOperator
   // exception: p is written to, which may mean the copy is intended
   and not p.getAnAccess().isAddressOfAccessNonConst()
-  and not exists(Access a |
-    a.getTarget() = p and
+  and not exists(Expr e |
+    variableAccessedAsValue(p.getAnAccess(), e.getFullyConverted()) and
     (
-      exists(Assignment an | an.getLValue().getAChild*() = a) or
-      exists(CrementOperation co | co.getOperand().getAChild*() = a) or
-      exists(FunctionCall fc | fc.getQualifier().getAChild*() = a and not fc.getTarget().hasSpecifier("const"))
+      exists(Assignment an | an.getLValue() = e) or
+      exists(CrementOperation co | co.getOperand() = e) or
+      exists(FunctionCall fc | fc.getQualifier() = e and not fc.getTarget().hasSpecifier("const"))
     )
   )
   // if there's no block, we can't tell how the parameter is used

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
@@ -7,3 +7,4 @@
 | test.cpp:107:16:107:16 | d | This parameter of type $@ is 4100 bytes - consider passing a const pointer/reference instead. | test.cpp:58:8:58:19 | MyLargeClass | MyLargeClass |
 | test.cpp:108:16:108:16 | e | This parameter of type $@ is 4100 bytes - consider passing a const pointer/reference instead. | test.cpp:58:8:58:19 | MyLargeClass | MyLargeClass |
 | test.cpp:109:16:109:16 | f | This parameter of type $@ is 4100 bytes - consider passing a const pointer/reference instead. | test.cpp:58:8:58:19 | MyLargeClass | MyLargeClass |
+| test.cpp:161:7:161:7 | b | This parameter of type $@ is 3208 bytes - consider passing a const pointer/reference instead. | test.cpp:153:8:153:10 | big | big |

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
@@ -158,7 +158,7 @@ struct big
 
 void myFunction7(
 		big a, // GOOD
-		big b // BAD [NOT DETECTED]
+		big b // BAD
 	)
 {
 	a.xs[0]++; // modifies a


### PR DESCRIPTION
Using `variableAccessedAsValue` fixes a FP because we can now distinguish modifications to the parameter from modifications to data _reachable from_ the parameter.