### PR TITLE
Swift: Add Swift to supported-frameworks.rst, supported-versions-compilers.rst and extractors.rst

### DIFF
--- a/docs/codeql/reusables/extractors.rst
+++ b/docs/codeql/reusables/extractors.rst
@@ -18,3 +18,5 @@
      - ``python``
    * - Ruby
      - ``ruby``
+   * - Swift
+     - ``swift``

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -292,7 +292,7 @@ and the CodeQL library pack ``codeql/swift-all`` (`changelog <https://github.com
    :widths: auto
 
    Name, Category
-   `AEXML <>`__, XML processing library
+   `AEXML <https://github.com/tadija/AEXML>`__, XML processing library
    `Alamofire <https://github.com/Alamofire/Alamofire>`__, Network communicator
    `Core Data <https://developer.apple.com/documentation/coredata/>`__, Database
    `CryptoKit <https://developer.apple.com/documentation/cryptokit/>`__, Cryptography library

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -282,6 +282,8 @@ and the CodeQL library pack ``codeql/ruby-all`` (`changelog <https://github.com/
 Swift built-in support
 ================================
 
+.. include:: ../reusables/swift-beta-note.rst
+
 Provided by the current versions of the
 CodeQL query pack ``codeql/swift-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/src>`__)
 and the CodeQL library pack ``codeql/swift-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/lib>`__).

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -278,3 +278,32 @@ and the CodeQL library pack ``codeql/ruby-all`` (`changelog <https://github.com/
    Ruby on Rails, Web framework
    rubyzip, Compression library
    typhoeus, HTTP client
+
+Swift built-in support
+================================
+
+Provided by the current versions of the
+CodeQL query pack ``codeql/swift-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/src>`__)
+and the CodeQL library pack ``codeql/swift-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/swift/ql/lib>`__).
+
+.. csv-table::
+   :header-rows: 1
+   :class: fullWidthTable
+   :widths: auto
+
+   Name, Category
+   `AEXML <>`__, XML processing library
+   `Alamofire <https://github.com/Alamofire/Alamofire>`__, Network communicator
+   `Core Data <https://developer.apple.com/documentation/coredata/>`__, Database
+   `CryptoKit <https://developer.apple.com/documentation/cryptokit/>`__, Cryptography library
+   `CryptoSwift <https://github.com/krzyzanowskim/CryptoSwift>`__, Cryptography library
+   `Foundation <https://developer.apple.com/documentation/foundation>`__, Utility library
+   `GRDB <https://github.com/groue/GRDB.swift>`__, Database
+   `JavaScriptCore <https://developer.apple.com/documentation/javascriptcore>`__, Scripting library
+   `Libxml2 <https://gitlab.gnome.org/GNOME/libxml2>`__, XML processing library
+   `Network <https://developer.apple.com/documentation/network>`__, Network communicator
+   `Realm Swift <https://realm.io/realm-swift/>`__, Database
+   `RNCryptor <https://github.com/RNCryptor/RNCryptor>`__, Cryptography library
+   `SQLite3 <https://sqlite.org/index.html>`__, Database
+   `SQLite.swift <https://github.com/stephencelis/SQLite.swift>`__, Database
+   `WebKit <https://developer.apple.com/documentation/webkit>`__, User interface library

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -24,6 +24,7 @@
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11",Not applicable,``.py``
    Ruby [9]_,"up to 3.2",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
+   Swift,"Swift 5.4-5.7","Swift compiler","``.swift``"
    TypeScript [10]_,"2.6-5.0",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -38,5 +38,5 @@
     .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
     .. [8] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
     .. [9] Requires glibc 2.17.
-    .. [10] Swift support is currently in beta. Windows is not supported. Linux support is partial (currently only works with Swift 5.7.3).
+    .. [10] Swift support is currently in beta. Support for the analysis of Swift 5.4-5.7 requires macOS. Swift 5.7.3 can also be analyzed using Linux.
     .. [11] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -24,8 +24,8 @@
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11",Not applicable,``.py``
    Ruby [9]_,"up to 3.2",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
-   Swift,"Swift 5.4-5.7","Swift compiler","``.swift``"
-   TypeScript [10]_,"2.6-5.0",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
+   Swift [10]_,"Swift 5.4-5.7","Swift compiler","``.swift``"
+   TypeScript [11]_,"2.6-5.0",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group
 
@@ -38,4 +38,5 @@
     .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
     .. [8] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
     .. [9] Requires glibc 2.17.
-    .. [10] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.
+    .. [10] Swift support is currently in beta. Windows is not supported. Linux support is partial (currently only works with Swift 5.7.3).
+    .. [11] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.


### PR DESCRIPTION
This is the same as https://github.com/github/codeql/pull/13080 but targets the branch of https://github.com/github/codeql/pull/12940 rather than `main`.  This should mean we get to see the tests all pass on all of the changes (in particular the one about `swift-beta-note.rst`) before finally merging into `main`.